### PR TITLE
Checking code with "Tag Assistant (by Google) ver 1.0.0"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.buildpath
 /.project
 /build.properties
+.idea

--- a/app/code/community/LUKA/GoogleAdWords/Block/Conversion.php
+++ b/app/code/community/LUKA/GoogleAdWords/Block/Conversion.php
@@ -331,6 +331,9 @@ class LUKA_GoogleAdWords_Block_Conversion extends Mage_Core_Block_Template
             $query['value'] = $value;
         }
 
+//        $query['guid'] = 'ON';
+//        $query['script'] = 0;
+
         /* @var $uri Zend_Uri_Http */
         $uri = Zend_Uri::factory($url);
         $uri->setQuery($query);

--- a/app/code/community/LUKA/GoogleAdWords/Block/Conversion.php
+++ b/app/code/community/LUKA/GoogleAdWords/Block/Conversion.php
@@ -331,8 +331,8 @@ class LUKA_GoogleAdWords_Block_Conversion extends Mage_Core_Block_Template
             $query['value'] = $value;
         }
 
-//        $query['guid'] = 'ON';
-//        $query['script'] = 0;
+        $query['guid'] = 'ON';
+        $query['script'] = 0;
 
         /* @var $uri Zend_Uri_Http */
         $uri = Zend_Uri::factory($url);

--- a/app/design/frontend/base/default/template/luka/google/adwords/conversion.phtml
+++ b/app/design/frontend/base/default/template/luka/google/adwords/conversion.phtml
@@ -33,6 +33,7 @@
     <!-- Google Conversion Code -->
     <div class="google-adwords-conversion-tracker">
         <script type="text/javascript">
+        /* <![CDATA[ */
         var google_conversion_id = <?php echo $this->getConversionId() ?>;
         var google_conversion_language = '<?php echo $this->jsQuoteEscape($this->getConversionLanguage()) ?>';
         var google_conversion_format = <?php echo $this->getConversionFormat() ?>;
@@ -43,6 +44,7 @@
         <?php if ($_value > 0): ?>
         var google_conversion_value = <?php echo $_value ?>;
         <?php endif ?>
+        /* ]]> */
         </script>
         <script type="text/javascript" src="<?php echo $this->getConversionScriptUrl() ?>"></script>
 


### PR DESCRIPTION
Checking code with "Tag Assistant (by Google) ver 1.0.0" …

Resolved
Error 1: Missing CDATA Comments
Error 2: Dynamic conversion value in wrong format in the <noscript> tag.

In my case it parse conversion value on end of link not correct.
I had link: <img height="1" width="1" style="border-style:none" alt="" src="http://www.googleadservices.com/pagead/conversion/ХХХХХХХХХ/?label=ХХХХХХХХХХХХХ&value=1.65" />

Tag assistent think that conversion value is 1.65" />
When we add additional params to link (value is not last parameter) then all is ok.
I add parameters from documentation: https://support.google.com/tagassistant/answer/2947038?ref_topic=2947092#cdata_comments