### PR TITLE
Removes useless protocol in urls

### DIFF
--- a/app/code/community/LUKA/GoogleAdWords/Block/Conversion.php
+++ b/app/code/community/LUKA/GoogleAdWords/Block/Conversion.php
@@ -282,13 +282,7 @@ class LUKA_GoogleAdWords_Block_Conversion extends Mage_Core_Block_Template
      */
     public function getConversionScriptUrl()
     {
-        $url = 'http://www.googleadservices.com/pagead/conversion.js';
-
-        if ($this->getRequest()->isSecure()) {
-            $url = 'https://www.googleadservices.com/pagead/conversion.js';
-        }
-
-        return $url;
+        return '//www.googleadservices.com/pagead/conversion.js';
     }
 
     /**
@@ -315,13 +309,7 @@ class LUKA_GoogleAdWords_Block_Conversion extends Mage_Core_Block_Template
      */
     public function getFallbackUrl()
     {
-        $url = 'http';
-
-        if ($this->getRequest()->isSecure()) {
-            $url .= 's';
-        }
-
-        $url .= '://www.googleadservices.com/pagead/conversion/'
+        $url = '//www.googleadservices.com/pagead/conversion/'
               . $this->getConversionId() . '/';
 
         $query = array('label' => $this->getConversionLabel());


### PR DESCRIPTION
It's not necessary to specify protocol (http / https) in script URLs.